### PR TITLE
Fix templates that generate incorrect labels

### DIFF
--- a/src/patterns/dosdp-patterns/malformedAnatomicalEntity.yaml
+++ b/src/patterns/dosdp-patterns/malformedAnatomicalEntity.yaml
@@ -1,36 +1,56 @@
-annotationProperties:
-  exact_synonym: oio:hasExactSynonym
-annotations:
-- annotationProperty: exact_synonym
-  text: malformed %s
-  vars:
-  - anatomical_entity
+---
+pattern_name: malformedAnatomicalEntity
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/malformedAnatomicalEntity.yaml
+
+description: 'Use this pattern to create phenotype categories where
+  the formation of one or more anatomical entities deviates from normal
+  resulting in distorted shapes.'
+
+#  examples:
+#    - http://purl.obolibrary.org/obo/ZP_0000446  # epibranchial
+#    ganglion malformed, abnormal
+#    - http://purl.obolibrary.org/obo/HP_0008554  # Cochlear malformation
+#    - http://purl.obolibrary.org/obo/MP_0006249  # phthisis bulbi
+
+contributors:
+  - https://orcid.org/0000-0002-7356-1779    # Nicolas Matentzoglu
+  - https://orcid.org/0000-0001-5208-3432    # Nicole Vasilevsky
+  - https://orcid.org/0000-0001-8314-2140    # Ray Stefancsik
+
 classes:
   abnormal: PATO:0000460
   anatomical entity: UBERON:0001062
   malformed: PATO:0000646
-contributors:
-- https://orcid.org/0000-0002-7356-1779
-- https://orcid.org/0000-0001-5208-3432
-def:
-  text: Formed/malformed %s.
-  vars:
-  - anatomical_entity
-description: ''
-equivalentTo:
-  text: '''has_part'' some (''malformed'' and (''inheres_in'' some %s) and (''has_modifier''
-    some ''abnormal''))'
-  vars:
-  - anatomical_entity
-name:
-  text: formed %s
-  vars:
-  - anatomical_entity
-pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/malformedAnatomicalEntity.yaml
-pattern_name: malformedAnatomicalEntity
+
 relations:
   has_modifier: RO:0002573
   has_part: BFO:0000051
-  inheres_in: RO:0000052
+  characteristic_of: RO:0000052
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+
 vars:
-  anatomical_entity: '''anatomical entity'''
+  anatomical_entity: "'anatomical entity'"
+
+name:
+  text: malformed %s
+  vars:
+    - anatomical_entity
+
+annotations:
+  - annotationProperty: exact_synonym
+    text: malformed %s
+    vars:
+      - anatomical_entity
+def:
+  text: Malformed %s.
+  vars:
+    - anatomical_entity
+equivalentTo:
+  text: "'has_part' some (
+          'malformed' and (
+          'characteristic_of' some %s) and
+          ('has_modifier' some 'abnormal'))"
+  vars:
+    - anatomical_entity

--- a/src/patterns/dosdp-patterns/malformedAnatomicalEntityInLocation.yaml
+++ b/src/patterns/dosdp-patterns/malformedAnatomicalEntityInLocation.yaml
@@ -1,43 +1,62 @@
-annotationProperties:
-  exact_synonym: oio:hasExactSynonym
-annotations:
-- annotationProperty: exact_synonym
-  text: malformed %s in %s
-  vars:
-  - anatomical_entity
-  - location
+---
+pattern_name: malformedAnatomicalEntityInLocation
+pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/malformedAnatomicalEntityInLocation.yaml
+
+description: 'Use this pattern to create phenotype categories where
+  the formation of one or more anatomical entities deviates from normal
+  resulting in distorted shapes in a particular location.'
+
+#  examples:
+#    - http://purl.obolibrary.org/obo/XXXXXXXXXX  # XXXXXXXXXXXX
+
+contributors:
+  - https://orcid.org/0000-0002-7356-1779    # Nicolas Matentzoglu
+  - https://orcid.org/0000-0001-5208-3432    # Nicole Vasilevsky
+  - https://orcid.org/0000-0001-8314-2140    # Ray Stefancsik
+
 classes:
   abnormal: PATO:0000460
   anatomical entity: UBERON:0001062
   independent continuant: BFO:0000004
   malformed: PATO:0000646
-contributors:
-- https://orcid.org/0000-0002-7356-1779
-- https://orcid.org/0000-0001-5208-3432
-def:
-  text: Formed/malformed %s in %s.
-  vars:
-  - anatomical_entity
-  - location
-description: ''
-equivalentTo:
-  text: '''has_part'' some (''malformed'' and (''inheres_in'' some (%s and (''part_of''
-    some %s))) and (''has_modifier'' some ''abnormal''))'
-  vars:
-  - anatomical_entity
-  - location
-name:
-  text: formed %s in %s
-  vars:
-  - anatomical_entity
-  - location
-pattern_iri: http://purl.obolibrary.org/obo/upheno/patterns-dev/malformedAnatomicalEntityInLocation.yaml
-pattern_name: malformedAnatomicalEntityInLocation
+
 relations:
   has_modifier: RO:0002573
   has_part: BFO:0000051
-  inheres_in: RO:0000052
+  characteristic_of: RO:0000052
   part_of: BFO:0000050
+
+annotationProperties:
+  exact_synonym: oio:hasExactSynonym
+
 vars:
-  anatomical_entity: '''anatomical entity'''
-  location: '''independent continuant'''
+  anatomical_entity: "'anatomical entity'"
+  location: "'independent continuant'"
+
+name:
+  text: malformed %s in %s
+  vars:
+    - anatomical_entity
+    - location
+
+annotations:
+  - annotationProperty: exact_synonym
+    text: malformed %s in %s
+    vars:
+      - anatomical_entity
+      - location
+
+def:
+  text: Malformed %s in %s.
+  vars:
+    - anatomical_entity
+    - location
+
+equivalentTo:
+  text: "'has_part' some (
+          'malformed' and (
+          'characteristic_of' some ( %s and ('part_of' some %s))) and
+          ('has_modifier' some 'abnormal'))"
+  vars:
+    - anatomical_entity
+    - location


### PR DESCRIPTION
Fix templates that generate incorrect labels that start with "formed" instead of the correct "malformed".

If applied, this commit will fix https://github.com/obophenotype/upheno/issues/983 .